### PR TITLE
Frame rate cap

### DIFF
--- a/Assets/Scripts/Menu.cs
+++ b/Assets/Scripts/Menu.cs
@@ -8,6 +8,7 @@ public class Menu : MonoBehaviour
 {
     private void Start()
     {
+        Application.targetFrameRate = 60;
         SFXManager.Instance.PlayBackgroundMusic(SFXManager.Instance.TitleScreen);
     }
 


### PR DESCRIPTION
Added a frame rate cap to the start of the main menu script. This won't be activated when you go straight into the game from the editor but you will always load the main menu first in builds of the game so this should work well.