### PR TITLE
Death Clarity

### DIFF
--- a/Assets/Prefabs/Enemies/Bosses/BombBoss.prefab
+++ b/Assets/Prefabs/Enemies/Bosses/BombBoss.prefab
@@ -127,7 +127,6 @@ GameObject:
   m_Component:
   - component: {fileID: 5656455698361903578}
   - component: {fileID: 5656455698361903576}
-  - component: {fileID: 4223785294766013922}
   - component: {fileID: 5279123959450887226}
   - component: {fileID: 7389167939081178781}
   - component: {fileID: -5168371847225776494}
@@ -199,58 +198,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1.75, y: 1.75}
   m_EdgeRadius: 0
---- !u!212 &4223785294766013922
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5656455698361903583}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 4, y: 4}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 0
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
 --- !u!50 &5279123959450887226
 Rigidbody2D:
   serializedVersion: 4

--- a/Assets/Prefabs/Enemies/Bosses/ShotgunBoss.prefab
+++ b/Assets/Prefabs/Enemies/Bosses/ShotgunBoss.prefab
@@ -95,7 +95,6 @@ GameObject:
   m_Component:
   - component: {fileID: 5656455698361903578}
   - component: {fileID: 5656455698361903576}
-  - component: {fileID: 4223785294766013922}
   - component: {fileID: 5279123959450887226}
   - component: {fileID: -1903474810788399424}
   m_Layer: 6
@@ -166,58 +165,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1.75, y: 1.75}
   m_EdgeRadius: 0
---- !u!212 &4223785294766013922
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5656455698361903583}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 4, y: 4}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 0
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
 --- !u!50 &5279123959450887226
 Rigidbody2D:
   serializedVersion: 4

--- a/Assets/Prefabs/Enemies/EnemyMelee/EnemyMelee.prefab
+++ b/Assets/Prefabs/Enemies/EnemyMelee/EnemyMelee.prefab
@@ -242,7 +242,6 @@ GameObject:
   - component: {fileID: 5656455698361903576}
   - component: {fileID: 69292089992521618}
   - component: {fileID: 1898390291498354045}
-  - component: {fileID: 4084434369929302475}
   m_Layer: 6
   m_Name: EnemyMelee
   m_TagString: Enemy
@@ -333,7 +332,7 @@ MonoBehaviour:
   mapManager: {fileID: 0}
   bleedTick: 1
   bleedInterval: 1
-  bleedTrue: 0
+  bleeding: 0
   player: {fileID: 0}
   attackRange: 1
 --- !u!50 &1898390291498354045
@@ -363,58 +362,6 @@ Rigidbody2D:
   m_SleepingMode: 1
   m_CollisionDetection: 1
   m_Constraints: 0
---- !u!212 &4084434369929302475
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5656455698361903583}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 0
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
 --- !u!1 &5656455699881316957
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/EnemyScripts/Bosses/BombBossBehaviour.cs
+++ b/Assets/Scripts/EnemyScripts/Bosses/BombBossBehaviour.cs
@@ -26,11 +26,6 @@ public class BombBossBehaviour : EnemyBase
 
         if (GameSettings.gameState != GameState.InGame || Dying) { return; }
 
-        if (Health <= 0)
-        {
-            StartCoroutine(Timeout.Instance.TimeoutEnemy(gameObject, 5f));
-            Dying = true;
-        }
         if (SkillEffects.Instance.decoyActive && !stopCheck)
         {
             player = GameObject.FindGameObjectWithTag("Decoy");

--- a/Assets/Scripts/EnemyScripts/Bosses/BombBossBehaviour.cs
+++ b/Assets/Scripts/EnemyScripts/Bosses/BombBossBehaviour.cs
@@ -23,13 +23,14 @@ public class BombBossBehaviour : EnemyBase
     }
     void Update()
     {
+
+        if (GameSettings.gameState != GameState.InGame || Dying) { return; }
+
         if (Health <= 0)
         {
-
-            Die();
+            StartCoroutine(Timeout.Instance.TimeoutEnemy(gameObject, 5f));
+            Dying = true;
         }
-        if (GameSettings.gameState != GameState.InGame) { return; }
-
         if (SkillEffects.Instance.decoyActive && !stopCheck)
         {
             player = GameObject.FindGameObjectWithTag("Decoy");

--- a/Assets/Scripts/EnemyScripts/Bosses/RadiusAttack.cs
+++ b/Assets/Scripts/EnemyScripts/Bosses/RadiusAttack.cs
@@ -23,7 +23,7 @@ public class RadiusAttack : MonoBehaviour
     }
     void Update()
     {
-        if (GameSettings.gameState != GameState.InGame){return;}
+        if (GameSettings.gameState != GameState.InGame || GetComponent<EnemyBase>().Dying){return;}
 
             if (attackCooldown <= 0)
             {

--- a/Assets/Scripts/EnemyScripts/Bosses/ShotgunBossBehaviour.cs
+++ b/Assets/Scripts/EnemyScripts/Bosses/ShotgunBossBehaviour.cs
@@ -48,13 +48,8 @@ public class ShotgunBossBehaviour : EnemyBase
 
     private void Update()
     {
-        if (Health <= 0)
-        {
-            StartCoroutine(Timeout.Instance.TimeoutEnemy(gameObject, 5f));
-            return;
-        }
 
-        if (GameSettings.gameState != GameState.InGame) return;
+        if (GameSettings.gameState != GameState.InGame || Dying) return;
         if (SkillEffects.Instance.decoyActive)
         {
             player = GameObject.FindGameObjectWithTag("Decoy");

--- a/Assets/Scripts/EnemyScripts/Bosses/ShotgunBossBehaviour.cs
+++ b/Assets/Scripts/EnemyScripts/Bosses/ShotgunBossBehaviour.cs
@@ -50,7 +50,7 @@ public class ShotgunBossBehaviour : EnemyBase
     {
         if (Health <= 0)
         {
-            Die();
+            StartCoroutine(Timeout.Instance.TimeoutEnemy(gameObject, 5f));
             return;
         }
 

--- a/Assets/Scripts/EnemyScripts/EnemyBase.cs
+++ b/Assets/Scripts/EnemyScripts/EnemyBase.cs
@@ -7,6 +7,7 @@ using System;
 
 public abstract class EnemyBase : MonoBehaviour
 {
+    public static EnemyBase Instance { get; private set;}
     public const float BLEED_INTERVAL = 1f;
     public GameObject damageText;
     public GameObject critText;
@@ -36,6 +37,12 @@ public abstract class EnemyBase : MonoBehaviour
     public int Points
     {
         get {return points;}
+    }
+    private bool dying;
+    public bool Dying
+    {
+        get {return dying;}
+        set {dying = value;}
     }
     public MapManager mapManager;
     public float bleedTick = 1f;
@@ -77,12 +84,6 @@ public abstract class EnemyBase : MonoBehaviour
         
     }
     public abstract void Move();
-    public virtual void Die()
-    {
-        SFXManager.Instance.PlaySFX("EnemyDie");
-        ScoreManager.Instance.IncreasePoints(Points);
-        StartCoroutine(Timeout.Instance.TimeoutEnemy(gameObject, 1f));
-    }
     public void ScaleStats()
     {
         baseHealth = (int)Math.Round(BaseHealth * endlessScalar);

--- a/Assets/Scripts/EnemyScripts/EnemyBase.cs
+++ b/Assets/Scripts/EnemyScripts/EnemyBase.cs
@@ -81,8 +81,7 @@ public abstract class EnemyBase : MonoBehaviour
     {
         SFXManager.Instance.PlaySFX("EnemyDie");
         ScoreManager.Instance.IncreasePoints(Points);
-        EnemySpawner.Instance.currentEnemies.Remove(gameObject);
-        Destroy(gameObject);
+        StartCoroutine(Timeout.Instance.TimeoutEnemy(gameObject, 1f));
     }
     public void ScaleStats()
     {

--- a/Assets/Scripts/EnemyScripts/EnemyMelee.cs
+++ b/Assets/Scripts/EnemyScripts/EnemyMelee.cs
@@ -22,11 +22,12 @@ public class EnemyMelee : EnemyBase
 
     void Update()
     {
-        if (GameSettings.gameState != GameState.InGame) {return;}
+        if (GameSettings.gameState != GameState.InGame || Dying) {return;}
 
         if (Health <= 0)
         {
-            Die();
+            StartCoroutine(Timeout.Instance.TimeoutEnemy(gameObject, 1f));
+            Dying = true;
         }
         Bleed();
 
@@ -88,11 +89,11 @@ public class EnemyMelee : EnemyBase
         transform.position = Vector2.MoveTowards(this.transform.position, player.transform.position, Speed * tileSpeedModifier * Time.deltaTime);
         transform.GetChild(0).rotation = Quaternion.Euler(Vector3.forward * angle);
     }
-    public override void Die()
-    {
-        SFXManager.Instance.PlaySFX("EnemyDie");
-        ScoreManager.Instance.IncreasePoints(Points);
-        EnemySpawner.Instance.currentEnemies.Remove(gameObject);
-        Destroy(gameObject);
-    }
+    // public override void Die()
+    // {
+    //     SFXManager.Instance.PlaySFX("EnemyDie");
+    //     ScoreManager.Instance.IncreasePoints(Points);
+    //     EnemySpawner.Instance.currentEnemies.Remove(gameObject);
+    //     Destroy(gameObject);
+    // }
 }

--- a/Assets/Scripts/EnemyScripts/EnemyMelee.cs
+++ b/Assets/Scripts/EnemyScripts/EnemyMelee.cs
@@ -83,11 +83,4 @@ public class EnemyMelee : EnemyBase
         transform.position = Vector2.MoveTowards(this.transform.position, player.transform.position, Speed * tileSpeedModifier * Time.deltaTime);
         transform.GetChild(0).rotation = Quaternion.Euler(Vector3.forward * angle);
     }
-    // public override void Die()
-    // {
-    //     SFXManager.Instance.PlaySFX("EnemyDie");
-    //     ScoreManager.Instance.IncreasePoints(Points);
-    //     EnemySpawner.Instance.currentEnemies.Remove(gameObject);
-    //     Destroy(gameObject);
-    // }
 }

--- a/Assets/Scripts/EnemyScripts/EnemyMelee.cs
+++ b/Assets/Scripts/EnemyScripts/EnemyMelee.cs
@@ -23,12 +23,6 @@ public class EnemyMelee : EnemyBase
     void Update()
     {
         if (GameSettings.gameState != GameState.InGame || Dying) {return;}
-
-        if (Health <= 0)
-        {
-            StartCoroutine(Timeout.Instance.TimeoutEnemy(gameObject, 1f));
-            Dying = true;
-        }
         Bleed();
 
         if (SkillEffects.Instance.decoyActive && !stopCheck)

--- a/Assets/Scripts/EnemyScripts/EnemyRanged.cs
+++ b/Assets/Scripts/EnemyScripts/EnemyRanged.cs
@@ -26,9 +26,9 @@ public class EnemyRanged : EnemyBase
         
         if (GameSettings.gameState != GameState.InGame || Dying) {return;}
 
-        if (Health <= 0)
-        {
-            StartCoroutine(Timeout.Instance.TimeoutEnemy(gameObject, 1f));
+        if (Health <= 0) 
+        { 
+            StartCoroutine(Die());
             Dying = true;
         }
         Bleed();

--- a/Assets/Scripts/EnemyScripts/EnemyRanged.cs
+++ b/Assets/Scripts/EnemyScripts/EnemyRanged.cs
@@ -101,12 +101,5 @@ public class EnemyRanged : EnemyBase
         float tileSpeedModifier = mapManager.GetTileWalkingSpeed(transform.position);
         transform.position = Vector2.MoveTowards(this.transform.position, player.transform.position, (Speed * tileSpeedModifier) * Time.deltaTime);
     }
-    
-    // public override void Die()
-    // {
-    //     SFXManager.Instance.PlaySFX("EnemyDie");
-    //     ScoreManager.Instance.IncreasePoints(Points);
-    //     EnemySpawner.Instance.currentEnemies.Remove(gameObject);
-    //     Destroy(gameObject);
-    // }
+
 }

--- a/Assets/Scripts/EnemyScripts/EnemyRanged.cs
+++ b/Assets/Scripts/EnemyScripts/EnemyRanged.cs
@@ -24,11 +24,12 @@ public class EnemyRanged : EnemyBase
     void Update()
     {
         
-        if (GameSettings.gameState != GameState.InGame) {return;}
+        if (GameSettings.gameState != GameState.InGame || Dying) {return;}
 
         if (Health <= 0)
         {
-            Die();
+            StartCoroutine(Timeout.Instance.TimeoutEnemy(gameObject, 1f));
+            Dying = true;
         }
         Bleed();
 
@@ -101,11 +102,11 @@ public class EnemyRanged : EnemyBase
         transform.position = Vector2.MoveTowards(this.transform.position, player.transform.position, (Speed * tileSpeedModifier) * Time.deltaTime);
     }
     
-    public override void Die()
-    {
-        SFXManager.Instance.PlaySFX("EnemyDie");
-        ScoreManager.Instance.IncreasePoints(Points);
-        EnemySpawner.Instance.currentEnemies.Remove(gameObject);
-        Destroy(gameObject);
-    }
+    // public override void Die()
+    // {
+    //     SFXManager.Instance.PlaySFX("EnemyDie");
+    //     ScoreManager.Instance.IncreasePoints(Points);
+    //     EnemySpawner.Instance.currentEnemies.Remove(gameObject);
+    //     Destroy(gameObject);
+    // }
 }

--- a/Assets/Scripts/GameSettings.cs
+++ b/Assets/Scripts/GameSettings.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 public enum GameState
 {
     InGame,
+    Dead,
     Paused,
     EndGame,
     ItemSelect,

--- a/Assets/Scripts/HealthBar/HealthBar.cs
+++ b/Assets/Scripts/HealthBar/HealthBar.cs
@@ -4,22 +4,29 @@ using UnityEngine.UIElements;
 
 public class HealthBar : MonoBehaviour
 {
+    public static HealthBar Instance;
     private Label healthText;
     private IMGUIContainer healthBar;
-    private float maxHealthBarSize;
     
     void Awake()
     {
+        if(Instance == null)
+        {
+            Instance = this;
+        }
+        else
+        {
+            Destroy(gameObject);
+        }
         VisualElement document = GetComponent<UIDocument>().rootVisualElement;
         healthText = document.Q<Label>("HealthNumber");
         healthBar = document.Q<IMGUIContainer>("Health");
-        maxHealthBarSize = healthBar.style.width.value.value;  //https://discussions.unity.com/t/parse-int-to-stylelength/880675/3
+      
     }
-
-    void Update()
+    public void UpdateHealthBar(int currentHealth, int maxHealth)
     {
-        float healthFraction = (float)PlayerStats.Instance.CurrentHealth / PlayerStats.Instance.MaxHealth; //As these are both ints now I need to cast one to a float
+        float healthFraction = (float)currentHealth / maxHealth; //As these are both ints now I need to cast one to a float
         healthBar.style.width = Length.Percent(healthFraction * 100);
-        healthText.text = PlayerStats.Instance.CurrentHealth.ToString("F0") + "/" + PlayerStats.Instance.MaxHealth.ToString("F0");
+        healthText.text = currentHealth.ToString("F0") + "/" + maxHealth.ToString("F0");
     }
 }

--- a/Assets/Scripts/Player/PlayerStats.cs
+++ b/Assets/Scripts/Player/PlayerStats.cs
@@ -57,8 +57,9 @@ public class PlayerStats : MonoBehaviour
         get {return currentHealth;}
         set
         {
-            currentHealth = Math.Min(value, MaxHealth);
+            currentHealth = Math.Min(Math.Max(0, value), MaxHealth);
             //Locks the current health to the max health
+            HealthBar.Instance.UpdateHealthBar(CurrentHealth, MaxHealth);
         }
     }
 
@@ -137,6 +138,9 @@ public class PlayerStats : MonoBehaviour
             return;
         }
         Instance = this;
+    }
+    void Start()
+    {
         CurrentHealth = MaxHealth;
     }
 
@@ -152,7 +156,7 @@ public class PlayerStats : MonoBehaviour
             CheckDot();
         }
 
-        if (currentHealth <= 0) //if the player dies
+        if (CurrentHealth <= 0) //if the player dies
         {
             GameSettings.gameState = GameState.Dead;
             StartCoroutine(Timeout.Instance.TimeoutPlayer(gameObject, 1f));
@@ -190,7 +194,7 @@ public class PlayerStats : MonoBehaviour
             Destroy(lifeEggs[lifeEggs.Count - 1]);
             lifeEggs.Remove(lifeEggs[lifeEggs.Count - 1]);
         }
-        //Debug.Log("Player health before collisions turned off: " + currentHealth);
+        //Debug.Log("Player health before collisions turned off: " + CurrentHealth);
         CurrentHealth = MaxHealth;
         StartCoroutine(DisableCollisionForDuration(2f));
     }
@@ -218,6 +222,6 @@ public class PlayerStats : MonoBehaviour
         //TODO: Multiple instances of damage shouldn't totally overlap. Maybe randomly offset them a bit?
         GameObject damageTextInst = Instantiate(damageText, gameObject.transform);
         damageTextInst.GetComponent<TextMeshPro>().text = damageTaken.ToString();
-        currentHealth -= damageTaken;
+        CurrentHealth -= damageTaken;
     }
 }

--- a/Assets/Scripts/Player/PlayerStats.cs
+++ b/Assets/Scripts/Player/PlayerStats.cs
@@ -154,14 +154,8 @@ public class PlayerStats : MonoBehaviour
 
         if (currentHealth <= 0) //if the player dies
         {
-            if (lifeEggs.Count > 0)
-            {
-                Respawn();
-            }
-            else
-            {
-                FindObjectOfType<GameManager>().GameOver();
-            }
+            GameSettings.gameState = GameState.Dead;
+            StartCoroutine(Timeout.Instance.TimeoutPlayer(gameObject, 1f));
         }
     }
 
@@ -185,7 +179,7 @@ public class PlayerStats : MonoBehaviour
         nextDotTick -= Time.fixedDeltaTime;
     }
 
-    void Respawn()
+    public void Respawn()
     {
         //This event currently has no listeners, it is here for future use 
         onPlayerRespawn?.Invoke();

--- a/Assets/Scripts/Terminal/TerminalBehaviour.cs
+++ b/Assets/Scripts/Terminal/TerminalBehaviour.cs
@@ -260,7 +260,6 @@ public class TerminalBehaviour : MonoBehaviour
             break;
             default:
                 output.text += "\nStat given is not a valid enterable stat\n\n";
-                return;
             break;
         }
         output.text += $"\nSet {stat} to {value}\n\n";             

--- a/Assets/Scripts/Timeout.cs
+++ b/Assets/Scripts/Timeout.cs
@@ -16,7 +16,7 @@ public class Timeout : MonoBehaviour
         Instance = this;
     }
 
-    public IEnumerator TimeoutEnemy(GameObject enemy, float duration)
+    public IEnumerator TimeoutEnemy(GameObject enemy, float duration) //this is currently broken becuase I cannot grab the instanced enemy to delete. (it is 1 am, i'll fix this tommorrow)
     {
         Debug.Log("This is being called correctly");
         SpriteRenderer sprite = enemy.GetComponentInChildren<SpriteRenderer>();
@@ -31,9 +31,12 @@ public class Timeout : MonoBehaviour
         }
 
         yield return new WaitForSeconds(duration);
+
+        SFXManager.Instance.PlaySFX("EnemyDie");
+        ScoreManager.Instance.IncreasePoints(EnemyBase.Instance.Points);
         
-        Debug.Log("This is culling the eneimes correctly");
         EnemySpawner.Instance.currentEnemies.Remove(enemy);
+        Debug.Log("This is culling the eneimes correctly");
         Destroy(enemy);
 
     }

--- a/Assets/Scripts/Timeout.cs
+++ b/Assets/Scripts/Timeout.cs
@@ -4,8 +4,67 @@ using UnityEngine;
 
 public class Timeout : MonoBehaviour
 {
-    public void DeathTimeout(float time, GameObject obj)
+    public static Timeout Instance;
+
+    void Awake()
     {
-        obj.AddComponent<Animator>();
+        if (Instance != null)
+        {
+            Destroy(this);
+            return;
+        }
+        Instance = this;
+    }
+
+    public IEnumerator TimeoutEnemy(GameObject enemy, float duration)
+    {
+        Debug.Log("This is being called correctly");
+        SpriteRenderer sprite = enemy.GetComponentInChildren<SpriteRenderer>();
+        
+        if (sprite != null)
+        {
+            sprite.color = new Color32(255, 0, 0, 128);
+        }
+        else
+        {
+            Debug.LogError("Did not get sprite, make sure enemy hierarchy has a sprite render");
+        }
+
+        yield return new WaitForSeconds(duration);
+        
+        Debug.Log("This is culling the eneimes correctly");
+        EnemySpawner.Instance.currentEnemies.Remove(enemy);
+        Destroy(enemy);
+
+    }
+
+    public IEnumerator TimeoutPlayer(GameObject player, float duration)
+    {
+
+        SpriteRenderer sprite = player.GetComponentInChildren<SpriteRenderer>();
+
+        if (sprite != null)
+        {
+            sprite.color = new Color32(255, 0, 0, 128);
+        }
+        else
+        {
+            Debug.LogError("Did not get sprite, make sure player hierarchy has a sprite render");
+        }
+
+
+        StartCoroutine(PlayerStats.Instance.DisableCollisionForDuration(duration));
+
+        yield return new WaitForSeconds(duration);
+        GameSettings.gameState = GameState.InGame;
+
+        if (PlayerStats.Instance.lifeEggs.Count > 0)
+        {
+            PlayerStats.Instance.Respawn();
+        }
+        else
+        {
+            FindObjectOfType<GameManager>().GameOver();
+        }
     }
 }

--- a/Assets/Scripts/Timeout.cs
+++ b/Assets/Scripts/Timeout.cs
@@ -1,0 +1,11 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Timeout : MonoBehaviour
+{
+    public void DeathTimeout(float time, GameObject obj)
+    {
+        obj.AddComponent<Animator>();
+    }
+}

--- a/Assets/Scripts/Timeout.cs
+++ b/Assets/Scripts/Timeout.cs
@@ -15,32 +15,6 @@ public class Timeout : MonoBehaviour
         }
         Instance = this;
     }
-
-    public IEnumerator TimeoutEnemy(GameObject enemy, float duration) //this is currently broken becuase I cannot grab the instanced enemy to delete. (it is 1 am, i'll fix this tommorrow)
-    {
-        Debug.Log("This is being called correctly");
-        SpriteRenderer sprite = enemy.GetComponentInChildren<SpriteRenderer>();
-        
-        if (sprite != null)
-        {
-            sprite.color = new Color32(255, 0, 0, 128);
-        }
-        else
-        {
-            Debug.LogError("Did not get sprite, make sure enemy hierarchy has a sprite render");
-        }
-
-        yield return new WaitForSeconds(duration);
-
-        SFXManager.Instance.PlaySFX("EnemyDie");
-        ScoreManager.Instance.IncreasePoints(EnemyBase.Instance.Points);
-        
-        EnemySpawner.Instance.currentEnemies.Remove(enemy);
-        Debug.Log("This is culling the eneimes correctly");
-        Destroy(enemy);
-
-    }
-
     public IEnumerator TimeoutPlayer(GameObject player, float duration)
     {
 

--- a/Assets/Scripts/Timeout.cs.meta
+++ b/Assets/Scripts/Timeout.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fe604023f01f5874d93cb30fbec538e4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/WaveManagement/Timer.cs
+++ b/Assets/Scripts/WaveManagement/Timer.cs
@@ -64,7 +64,7 @@ public class Timer : MonoBehaviour
             }
         }
 
-        if (currentTime <= 0 || (BossHealth.Instance.boss != null && BossHealth.Instance.boss.Health <= 0))
+        if (currentTime <= 0 || (waveNumber % 5 == 0 && BossHealth.Instance.boss == null))
         {
             if (waveNumber == 25 && GameSettings.gameState == GameState.InGame)
             {


### PR DESCRIPTION
## Describe your changes

Currently, it is very jarring when you or bosses die and you get teleported back to the nest or the item panel pops up after you defeat a boss. This PR adds a small timeout where the game pauses before teleporting you back to the spawn point. For bosses it will stop them from moving and they will take longer to die (room to add animation). 

## Issue number and link

#105 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
