### PR TITLE
General balance changes

### DIFF
--- a/Assets/Prefabs/Enemies/Bosses/BossAttacks/ShadowShockwave.prefab
+++ b/Assets/Prefabs/Enemies/Bosses/BossAttacks/ShadowShockwave.prefab
@@ -120,7 +120,7 @@ CircleCollider2D:
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
   serializedVersion: 2
-  m_Radius: 0.56
+  m_Radius: 0.5
 --- !u!114 &-2927032742812986046
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -134,3 +134,5 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   player: {fileID: 0}
+  playerHit: 0
+  originEnemy: {fileID: 0}

--- a/Assets/Prefabs/Enemies/EnemyMelee/EnemyMelee Level 2.prefab
+++ b/Assets/Prefabs/Enemies/EnemyMelee/EnemyMelee Level 2.prefab
@@ -327,12 +327,12 @@ MonoBehaviour:
   critText: {fileID: 391528759432483411, guid: f288eb3865634874f8d46dff2686a205, type: 3}
   baseHealth: 30
   damage: 25
-  speed: 5
+  speed: 6
   points: 20
   mapManager: {fileID: 0}
   bleedTick: 1
   bleedInterval: 1
-  bleedTrue: 0
+  bleeding: 0
   player: {fileID: 0}
   attackRange: 1
 --- !u!50 &1898390291498354045

--- a/Assets/Prefabs/Enemies/EnemyMelee/EnemyMelee Level 2.prefab
+++ b/Assets/Prefabs/Enemies/EnemyMelee/EnemyMelee Level 2.prefab
@@ -327,7 +327,7 @@ MonoBehaviour:
   critText: {fileID: 391528759432483411, guid: f288eb3865634874f8d46dff2686a205, type: 3}
   baseHealth: 30
   damage: 25
-  speed: 6
+  speed: 7
   points: 20
   mapManager: {fileID: 0}
   bleedTick: 1

--- a/Assets/Prefabs/Enemies/EnemyMelee/EnemyMelee Level 3.prefab
+++ b/Assets/Prefabs/Enemies/EnemyMelee/EnemyMelee Level 3.prefab
@@ -327,12 +327,12 @@ MonoBehaviour:
   critText: {fileID: 391528759432483411, guid: f288eb3865634874f8d46dff2686a205, type: 3}
   baseHealth: 40
   damage: 25
-  speed: 7
+  speed: 9
   points: 30
   mapManager: {fileID: 0}
   bleedTick: 1
   bleedInterval: 1
-  bleedTrue: 0
+  bleeding: 0
   player: {fileID: 0}
   attackRange: 1
 --- !u!50 &1898390291498354045

--- a/Assets/Prefabs/Enemies/EnemyMelee/EnemyMelee Level 4.prefab
+++ b/Assets/Prefabs/Enemies/EnemyMelee/EnemyMelee Level 4.prefab
@@ -327,12 +327,12 @@ MonoBehaviour:
   critText: {fileID: 391528759432483411, guid: f288eb3865634874f8d46dff2686a205, type: 3}
   baseHealth: 50
   damage: 30
-  speed: 7
+  speed: 8
   points: 40
   mapManager: {fileID: 0}
   bleedTick: 1
   bleedInterval: 1
-  bleedTrue: 0
+  bleeding: 0
   player: {fileID: 0}
   attackRange: 1
 --- !u!50 &1898390291498354045

--- a/Assets/Prefabs/Enemies/EnemyMelee/EnemyMelee Level 4.prefab
+++ b/Assets/Prefabs/Enemies/EnemyMelee/EnemyMelee Level 4.prefab
@@ -327,7 +327,7 @@ MonoBehaviour:
   critText: {fileID: 391528759432483411, guid: f288eb3865634874f8d46dff2686a205, type: 3}
   baseHealth: 50
   damage: 30
-  speed: 8
+  speed: 10
   points: 40
   mapManager: {fileID: 0}
   bleedTick: 1

--- a/Assets/Prefabs/Enemies/EnemyMelee/EnemyMelee Level 5.prefab
+++ b/Assets/Prefabs/Enemies/EnemyMelee/EnemyMelee Level 5.prefab
@@ -327,12 +327,12 @@ MonoBehaviour:
   critText: {fileID: 391528759432483411, guid: f288eb3865634874f8d46dff2686a205, type: 3}
   baseHealth: 70
   damage: 35
-  speed: 7
+  speed: 9
   points: 50
   mapManager: {fileID: 0}
   bleedTick: 1
   bleedInterval: 1
-  bleedTrue: 0
+  bleeding: 0
   player: {fileID: 0}
   attackRange: 1
 --- !u!50 &1898390291498354045

--- a/Assets/Prefabs/Enemies/EnemyMelee/EnemyMelee Level 5.prefab
+++ b/Assets/Prefabs/Enemies/EnemyMelee/EnemyMelee Level 5.prefab
@@ -327,7 +327,7 @@ MonoBehaviour:
   critText: {fileID: 391528759432483411, guid: f288eb3865634874f8d46dff2686a205, type: 3}
   baseHealth: 70
   damage: 35
-  speed: 9
+  speed: 11
   points: 50
   mapManager: {fileID: 0}
   bleedTick: 1

--- a/Assets/Resources/items.json
+++ b/Assets/Resources/items.json
@@ -27,7 +27,7 @@
       {
         "id": 3,
         "name": "Band-Aid",
-        "desc": "Gain 1% max health regeneration per 3 seconds",
+        "desc": "Gain 2% max health regeneration per 2 seconds",
         "rarity": 2,
         "stacks": 0
       },

--- a/Assets/Resources/items.json
+++ b/Assets/Resources/items.json
@@ -208,7 +208,7 @@
       {
         "id": 28,
         "name": "MOAB",
-        "desc": "Your explosions double in size, but they also do half damage to you",
+        "desc": "Your explosions double in size and deal 50% more damage",
         "rarity": 3,
         "weapons": ["RocketLauncher"],
         "stacks": 0

--- a/Assets/Resources/items.json
+++ b/Assets/Resources/items.json
@@ -157,7 +157,7 @@
       {
         "id": 21,
         "name": "Bigger Barrel",
-        "desc": "Add another 6 pellets to your shots",
+        "desc": "Add another 4 pellets to your shots",
         "rarity": 3,
         "weapons": ["Shotgun"],
         "stacks": 0

--- a/Assets/Resources/skills.json
+++ b/Assets/Resources/skills.json
@@ -19,7 +19,7 @@
         "name": "Vanish",
         "desc": "Cloak yourself and take no damage.",
         "cooldown": 15,
-        "duration": 5
+        "duration": 4
       },
       {
         "id" : 3,

--- a/Assets/Scripts/EnemyScripts/Bosses/BossBullet.cs
+++ b/Assets/Scripts/EnemyScripts/Bosses/BossBullet.cs
@@ -40,7 +40,7 @@ public class BossBullet : MonoBehaviour
 
         // Set bullet damage based on current wave
         bulletDamage = 30 + (GameSettings.waveNumber / 5) * 5;
-        bulletSpeed = 5 + (GameSettings.waveNumber / 5) * 3;
+        bulletSpeed = 5 + (GameSettings.waveNumber / 5);
         range = 20f + (GameSettings.waveNumber / 5) * 20;
 
         // Calculate direction based on whether it's a shotgun bullet

--- a/Assets/Scripts/EnemyScripts/Bosses/ShadowAttack.cs
+++ b/Assets/Scripts/EnemyScripts/Bosses/ShadowAttack.cs
@@ -75,7 +75,7 @@ public class ShadowAttack : MonoBehaviour
             Destroy(gameObject);
         }
 
-        if (duration >= .5)
+        if (duration > .2)
         {
             // Dynamically calculate the follow speed based on the player's move speed
             float playerSpeed = TopDownMovement.Instance.MoveSpeed;

--- a/Assets/Scripts/EnemyScripts/Bosses/ShotgunBossBehaviour.cs
+++ b/Assets/Scripts/EnemyScripts/Bosses/ShotgunBossBehaviour.cs
@@ -10,8 +10,10 @@ public class ShotgunBossBehaviour : EnemyBase
     [SerializeField] private Transform bulletPosition;
     private float attackRange = 10;
     private float attackInterval = 1.5f;
-    private float minJumpAttackInterval = 7f;
-    private float maxJumpAttackInterval = 12f;
+    private float[] minIntervalRange = { 10f, 8f, 7f, 6f };
+    private float minJumpAttackInterval = 10f;
+    private float[] maxIntervalRange = { 15f, 13f, 11f, 10f };
+    private float maxJumpAttackInterval = 15f;
     private float attackResumptionDelay = 2f; // New variable for delay after shadow attack
     private float initialShootingDelay = 2f; // New variable for initial delay
 
@@ -36,6 +38,25 @@ public class ShotgunBossBehaviour : EnemyBase
 
         Transform spriteChild = transform.Find("Sprite");
         bossSpriteRenderer = spriteChild ? spriteChild.GetComponent<SpriteRenderer>() : null;
+        switch (GameSettings.waveNumber)
+        {
+            case 5:
+                minJumpAttackInterval = minIntervalRange[0];
+                maxJumpAttackInterval = maxIntervalRange[0];
+                break;
+            case 10:
+                minJumpAttackInterval = minIntervalRange[1];
+                maxJumpAttackInterval = maxIntervalRange[1];
+                break;
+            case 15:
+                minJumpAttackInterval = minIntervalRange[2];
+                maxJumpAttackInterval = maxIntervalRange[2];
+                break;
+            default:
+                minJumpAttackInterval = minIntervalRange[3];
+                maxJumpAttackInterval = maxIntervalRange[3];
+                break;
+        }
 
         bossCollider = GetComponent<Collider2D>();
         if (bossCollider == null)

--- a/Assets/Scripts/EnemyScripts/EnemyExplosion.cs
+++ b/Assets/Scripts/EnemyScripts/EnemyExplosion.cs
@@ -22,9 +22,7 @@ public class EnemyExplosion : MonoBehaviour
      
     void Start()
     {
-
         ExplosionSize = 6;
- 
         StartCoroutine(DestroyExplosion());
     }
     private IEnumerator DestroyExplosion()
@@ -37,11 +35,8 @@ public class EnemyExplosion : MonoBehaviour
     {
         if (other.gameObject.CompareTag("Player"))
         {
-           
-           DestroyExplosion();
-            other.gameObject.GetComponent<PlayerStats>().ReceiveDamage(10);
-          
-           
+            DestroyExplosion();
+            other.gameObject.GetComponent<PlayerStats>().ReceiveDamage(5 + GameSettings.waveNumber);
         }
     }
 }

--- a/Assets/Scripts/EnemyScripts/Shockwave.cs
+++ b/Assets/Scripts/EnemyScripts/Shockwave.cs
@@ -30,7 +30,7 @@ public class Shockwave : MonoBehaviour
 
         shockwaveDamage = 30 + GameSettings.waveNumber;
         player = GameObject.FindGameObjectWithTag("Player");
-        ShockwaveSize = 12;
+        ShockwaveSize = 16;
 
         StartCoroutine(DestroyExplosion());
     }

--- a/Assets/Scripts/GameSettings.cs
+++ b/Assets/Scripts/GameSettings.cs
@@ -34,6 +34,6 @@ public static class GameSettings
     public static int waveNumber;
     public static SkillEnum activeSkill = SkillEnum.dash;
     public static controlType controlType;
-    public static int MaxRerollCharges = 2; //Starting this at 2 for the moment
+    public static int StartingRerollCharges = 1;
     public static GameMode gameMode = GameMode.Boss; //Boss mode by default if you start the game from the main scene
 }

--- a/Assets/Scripts/Items/ItemEffectTable.cs
+++ b/Assets/Scripts/Items/ItemEffectTable.cs
@@ -17,59 +17,59 @@ public class ItemEffectTable : MonoBehaviour
             case -1:
                 Debug.Log("Item choice skipped");
                 break;
-            case 0:
+            case 0: //Sharpened Talons
                 WeaponStats.Instance.FlatDamage += 10;
                 Debug.Log($"Damage: {WeaponStats.Instance.Damage}");
                 break;
-            case 01:
+            case 01: //Oats
                 PlayerStats.Instance.PercentBonusHealth += 10;
                 Debug.Log($"Max health: {PlayerStats.Instance.MaxHealth}");
                 break;
-            case 02:
+            case 02: //Boots
                 TopDownMovement.Instance.PercentBonusSpeed += 5;
                 Debug.Log($"Speed: {TopDownMovement.Instance.MoveSpeed}");
                 break;
-            case 03:
-                PlayerStats.Instance.FlatRegenerationPercentage += 1;
+            case 03: //Band-Aid
+                PlayerStats.Instance.FlatRegenerationPercentage += 2;
                 Debug.Log($"Regeneration Percentage: {PlayerStats.Instance.RegenerationPercentage}");
                 break;
-            case 04:
+            case 04: //Illegal Trigger
                 WeaponStats.Instance.PercentageFireDelay -= 10; //This makes it shoot 10% faster
                 Debug.Log($"Fire delay: {WeaponStats.Instance.FireDelay}");
                 break;
-            case 05:
+            case 05: //Chompers
                 WeaponStats.Instance.ItemBleedDamage += 1; //2% max health bleed per second
                 Debug.Log($"Bleed amount: {WeaponStats.Instance.BleedDamage}");
                 break;
-            case 06:
+            case 06: //Leech
                 PlayerStats.Instance.FlatLifestealPercentage += 1;
                 Debug.Log($"Lifesteal percentage: {PlayerStats.Instance.LifestealPercentage}");
                 break;
-            case 07:
+            case 07: //Explosive Bullets
                 WeaponStats.Instance.ItemExplosiveBullets = true;
                 WeaponStats.Instance.ItemExplosionSize += 2;
                 WeaponStats.Instance.ItemExplosionDamage += 50; //50% of the weapon damage as an explosion. Unsure about the balance 
                 Debug.Log($"Explosion size: {WeaponStats.Instance.ExplosionSize}");
                 Debug.Log($"Explosion damage: {WeaponStats.Instance.ExplosionDamage}");
                 break;
-            case 08:
+            case 08: //Egg
                 //This is going to be changed to not being actual items on the ground
                 GameObject newEgg = Instantiate(eggPrefab,  new Vector3(0,0,0), Quaternion.identity, GameObject.Find("Nest").transform);
                 newEgg.transform.localScale = new Vector3(1f/3f, 1f/3f, 1f/3f); //Properly setting the scale to one third
                 break;
-            case 09:
+            case 09: //Lucky Feather
                 WeaponStats.Instance.FlatCritChance += 8; //8% crit chance
                 Debug.Log($"Crit Chance: {WeaponStats.Instance.CritChance}");
                 break;
-            case 10:
+            case 10: //Super Charger
                 WeaponStats.Instance.PercentageFireDelay -= 30; //This makes it shoot 30% faster
                 Debug.Log($"Fire delay: {WeaponStats.Instance.FireDelay}");
                 break;
-            case 11:
+            case 11: //Eye of the Eagle
                 WeaponStats.Instance.FlatCritChance += 24; //24% crit chance
                 Debug.Log($"Crit Chance: {WeaponStats.Instance.CritChance}");
                 break;
-            case 12:
+            case 12: //Lucky Dive
                 List<int> randomStats = new List<int> {0, 1, 2, 3, 4, 5};
                 // Shuffle the list using LINQ
                 randomStats = randomStats.OrderBy(x => UnityEngine.Random.value).ToList();
@@ -105,35 +105,35 @@ public class ItemEffectTable : MonoBehaviour
                     }
                 }
                 break;
-            case 13:
+            case 13: //Shotgun
                 WeaponStats.Instance.CurrentWeapon = WeaponType.Shotgun;
                 Debug.Log($"Current Weapon: {WeaponStats.Instance.CurrentWeapon}");
                 break;
-            case 14:
+            case 14://Sniper
                 WeaponStats.Instance.CurrentWeapon = WeaponType.Sniper;
                 Debug.Log($"Current Weapon: {WeaponStats.Instance.CurrentWeapon}");
                 break;
-            case 15:
+            case 15: //Machine Gun
                 WeaponStats.Instance.CurrentWeapon = WeaponType.MachineGun;
                 Debug.Log($"Current Weapon: {WeaponStats.Instance.CurrentWeapon}");
                 break;
-            case 16:
+            case 16: //Dual Pistol
                 WeaponStats.Instance.CurrentWeapon = WeaponType.DualPistol;
                 Debug.Log($"Current Weapon: {WeaponStats.Instance.CurrentWeapon}");
                 break;
-            case 17:
+            case 17: //Rocket Launcher
                 WeaponStats.Instance.CurrentWeapon = WeaponType.RocketLauncher;
                 Debug.Log($"Current Weapon: {WeaponStats.Instance.CurrentWeapon}");
                 break;
-            case 18:
+            case 18: //Sword
                 WeaponStats.Instance.CurrentWeapon = WeaponType.Sword;
                 Debug.Log($"Current Weapon: {WeaponStats.Instance.CurrentWeapon}");
                 break;
-            case 19:
+            case 19: //Ricochet
                 WeaponStats.Instance.RicochetCount += 1;
                 Debug.Log($"Ricochet count: {WeaponStats.Instance.RicochetCount}");
                 break;
-            case 20:
+            case 20: //Piercing Bullets
                 WeaponStats.Instance.ItemPiercing = true;
                 WeaponStats.Instance.ItemPierceAmount += 1;
                 Debug.Log($"Piercing: {WeaponStats.Instance.PierceAmount}");

--- a/Assets/Scripts/Items/ItemEffectTable.cs
+++ b/Assets/Scripts/Items/ItemEffectTable.cs
@@ -138,22 +138,22 @@ public class ItemEffectTable : MonoBehaviour
                 WeaponStats.Instance.ItemPierceAmount += 1;
                 Debug.Log($"Piercing: {WeaponStats.Instance.PierceAmount}");
                 break;
-            case 21:
-                WeaponStats.Instance.ItemExtraBullets += 6;
+            case 21: //Bigger Barrel
+                WeaponStats.Instance.ItemExtraBullets += 4;
                 Debug.Log($"Extra bullets: {WeaponStats.Instance.ExtraBullets}");
                 break;
-            case 22:
+            case 22: //Spine Plate
                 TopDownMovement.Instance.PercentBonusSpeed *= 0.75f; //3/4 the speed
                 PlayerStats.Instance.SpinePlate = true;
                 PlayerStats.Instance.SpinePercent += 200; //200% of damage taken is dealt to the enemy per stack
                 Debug.Log($"Speed: {TopDownMovement.Instance.MoveSpeed}");
                 break;
-            case 23:
+            case 23: //Glass Cannon
                 PlayerStats.Instance.PercentBonusHealth /= 2; //Half the current max health. If this is picked multiple times it will keep halving the max health
                 WeaponStats.Instance.PercentageDamage *= 2; //Double the damage. If this is picked multiple times it will keep doubling the damage 
                 Debug.Log($"Max health: {PlayerStats.Instance.MaxHealth}. Damage: {WeaponStats.Instance.Damage}");
                 break;
-            case 24:
+            case 24: //Bloodletter's Curse
                 //This gives 30% of your damage as lifesteal and then doubles all your lifesteal
                 //This means it gives 60% total and doubles the effectiveness of all other lifesteal
                 PlayerStats.Instance.FlatLifestealPercentage += 30;
@@ -163,16 +163,16 @@ public class ItemEffectTable : MonoBehaviour
                 Debug.Log($"Lifesteal percentage: {PlayerStats.Instance.LifestealPercentage}");
                 Debug.Log($"Dot tick: {PlayerStats.Instance.DotDamage}");
                 break;
-            case 25:
+            case 25: //Weak Spots
                 WeaponStats.Instance.FlatCritDamage += 8; //48% crit damage
                 Debug.Log($"Crit Damage: {WeaponStats.Instance.CritDamage}");
                 break;
-            case 26:
+            case 26: //Stone Wall
                 PlayerStats.Instance.PercentBonusHealth *= 2; //Double the current max health
                 WeaponStats.Instance.PercentageDamage /= 2; //Half the damage
                 Debug.Log($"Max health: {PlayerStats.Instance.MaxHealth}. Damage: {WeaponStats.Instance.Damage}");
                 break;
-            case 27:
+            case 27: //Radiating Bombs
                 WeaponStats.Instance.ItemRadioactive = true;
                 WeaponStats.Instance.RadiationDamagePercentage += 10;
                 Debug.Log($"Radiation damage: {WeaponStats.Instance.RadiationDamage}");

--- a/Assets/Scripts/Items/ItemEffectTable.cs
+++ b/Assets/Scripts/Items/ItemEffectTable.cs
@@ -177,12 +177,13 @@ public class ItemEffectTable : MonoBehaviour
                 WeaponStats.Instance.RadiationDamagePercentage += 10;
                 Debug.Log($"Radiation damage: {WeaponStats.Instance.RadiationDamage}");
                 break;
-            case 28:
-                WeaponStats.Instance.SelfDamageExplosions = true;
+            case 28: //MOAB
                 WeaponStats.Instance.PercentageExplosionSize += 100;
-                Debug.Log($"Self damage {WeaponStats.Instance.SelfDamageExplosions}");
+                WeaponStats.Instance.ItemExplosionDamage += 50;
+                Debug.Log($"Explosion size: {WeaponStats.Instance.ExplosionSize}");
+                Debug.Log($"Explosion damage: {WeaponStats.Instance.ExplosionDamage}");
                 break;
-            case 29:
+            case 29: //Sword of the Master
                 if (!WeaponStats.Instance.HasSwordBeam)
                 {
                     WeaponStats.Instance.HasSwordBeam = true;
@@ -195,26 +196,26 @@ public class ItemEffectTable : MonoBehaviour
                     Debug.Log($"Player already has sword beam");
                 }
                 break;
-            case 30:
+            case 30: //Overheat - UNIMPLEMENTED
                 Debug.Log("Unimplemented Overheating item");
                 break;
-            case 31:
+            case 31: //Rocket boots
                 TopDownMovement.Instance.PercentBonusSpeed += 15;
                 Debug.Log($"Speed: {TopDownMovement.Instance.MoveSpeed}");
                 break;
-            case 32:
+            case 32: //Full Breakfast
                 PlayerStats.Instance.PercentBonusHealth += 30;
                 Debug.Log($"Max health: {PlayerStats.Instance.MaxHealth}");
                 break;
-            case 33:
+            case 33: //Expert Aim
                 WeaponStats.Instance.FlatCritDamage += 24; //24% crit damage
                 Debug.Log($"Crit Damage: {WeaponStats.Instance.CritDamage}");
                 break;
-            case 34:
+            case 34: //Hollow-point bullets
                 WeaponStats.Instance.FlatDamage += 30;
                 Debug.Log($"Damage: {WeaponStats.Instance.Damage}");
                 break;
-            case 35:
+            case 35: //Reflector
                 if (!WeaponStats.Instance.HasReflector)
                 {
                     Debug.Log($"Gained reflector");
@@ -226,7 +227,7 @@ public class ItemEffectTable : MonoBehaviour
                     Debug.Log($"Reflector cooldown reduced to {WeaponStats.Instance.ReflectCooldown}");
                 }
                 break;
-            case 36:
+            case 36: //Claymore
                 WeaponStats.Instance.PercentageDamage *= 4;
                 WeaponStats.Instance.WeaponFireDelay *= 3;
                 break;

--- a/Assets/Scripts/Items/ItemPanel.cs
+++ b/Assets/Scripts/Items/ItemPanel.cs
@@ -90,7 +90,7 @@ public class ItemPanel : MonoBehaviour
         confirmPanel.style.display = DisplayStyle.None;
         continuePanel.style.display = DisplayStyle.None;
 
-        rerollCharges = GameSettings.MaxRerollCharges;
+        rerollCharges = GameSettings.StartingRerollCharges;
         rand = new System.Random();
         LoadItems();
         
@@ -150,6 +150,10 @@ public class ItemPanel : MonoBehaviour
 
     public void InitializeItemPanel(int waveNumber) //this is called every time the inventory ui pops up
     {
+        if (waveNumber % 5 == 0) //Add one reroll charge after boss kills
+        {
+            rerollCharges++;
+        }
         statDisplay.UpdateStats();
         GetItems(3, waveNumber);
         VisualElement rerollCount = reroll.Q<VisualElement>("RerollCount");

--- a/Assets/Scripts/Player/Bullet.cs
+++ b/Assets/Scripts/Player/Bullet.cs
@@ -52,13 +52,8 @@ public class Bullet : MonoBehaviour
 
     void OnCollisionEnter2D(Collision2D other)
     { 
-        if (other.gameObject.CompareTag("Shield"))
-        {
-            Destroy(gameObject);
-            other.gameObject.GetComponent<RiotShield>().TakeDamage();
-        }
         //destroys bullet on hit with player and lowers health
-        if (other.gameObject.CompareTag("Enemy"))
+        if (other.gameObject.CompareTag("Enemy") || other.gameObject.CompareTag("Shield"))
         {
 
             if (WeaponStats.Instance.ExplosiveBullets)
@@ -71,14 +66,18 @@ public class Bullet : MonoBehaviour
                 {
                     explosionScript.ExplosionDamage = (WeaponStats.Instance.ExplosionDamage * WeaponStats.Instance.CritDamage) / 100;
                 }
-               
                 else
                 {
                     explosionScript.ExplosionDamage = WeaponStats.Instance.ExplosionDamage;
                 }
             }
+            if (other.gameObject.CompareTag("Shield"))
+            {
+                other.gameObject.GetComponent<RiotShield>().TakeDamage();
+                Destroy(gameObject);
+            }
             //Making the rocket launcher not deal base bullet damage, only explosion damage
-            if (WeaponStats.Instance.CurrentWeapon != WeaponType.RocketLauncher)
+            else if (WeaponStats.Instance.CurrentWeapon != WeaponType.RocketLauncher)
             {
                 if (crit)
                 {

--- a/Assets/Scripts/Player/PlayerExplosion.cs
+++ b/Assets/Scripts/Player/PlayerExplosion.cs
@@ -46,9 +46,5 @@ public class PlayerExplosion : MonoBehaviour
         {
             other.gameObject.GetComponent<EnemyBase>().ReceiveDamage(explosionDamage, crit);
         }
-        if (WeaponStats.Instance.SelfDamageExplosions && other.gameObject.CompareTag("Player"))
-        {
-            other.gameObject.GetComponent<PlayerStats>().ReceiveDamage(explosionDamage/2);
-        }
     }
 }

--- a/Assets/Scripts/Player/PlayerExplosion.cs
+++ b/Assets/Scripts/Player/PlayerExplosion.cs
@@ -46,5 +46,9 @@ public class PlayerExplosion : MonoBehaviour
         {
             other.gameObject.GetComponent<EnemyBase>().ReceiveDamage(explosionDamage, crit);
         }
+        else if (other.gameObject.CompareTag("Shield"))
+        {
+            other.gameObject.GetComponent<RiotShield>().TakeDamage();
+        }
     }
 }

--- a/Assets/Scripts/Player/PlayerStats.cs
+++ b/Assets/Scripts/Player/PlayerStats.cs
@@ -80,7 +80,7 @@ public class PlayerStats : MonoBehaviour
     private float nextDotTick = 0; //Time of the next damage over time tick
 
     //Regeneration
-    private float healTick = 3; //Time between healing ticks
+    private float healTick = 2; //Time between healing ticks
     public float HealTick
     {
         get {return healTick;}

--- a/Assets/Scripts/Player/WeaponStats.cs
+++ b/Assets/Scripts/Player/WeaponStats.cs
@@ -389,13 +389,7 @@ public class WeaponStats : MonoBehaviour
     {
         get { return ItemExplosiveBullets || WeaponExplosiveBullets; } //This will return true if either the weapon or an item has explosive bullets
     }
-    private bool selfDamageExplosions = false;
-    public bool SelfDamageExplosions
-    {
-        get {return selfDamageExplosions;}
-        set {selfDamageExplosions = value;}
-    }
-
+    
     //Explosion size
     private int itemExplosionSize = 0;
     public int ItemExplosionSize

--- a/Assets/Scripts/Player/WeaponStats.cs
+++ b/Assets/Scripts/Player/WeaponStats.cs
@@ -173,13 +173,13 @@ public class WeaponStats : MonoBehaviour
 
                 case WeaponType.RocketLauncher: //Placeholder for the rocket launcher
                     WeaponExplosiveBullets = true; //Rocket launcher has explosive bullets
-                    WeaponExplosionSize = 5; //Explosion size is 10
+                    WeaponExplosionSize = 5; //Explosion size is 5
                     WeaponExplosionDamage = 100; //100% of the weapon's damage is dealt as explosion damage
-                    WeaponFireDelay = 300; //300% fire delay
+                    WeaponFireDelay = 200; //300% fire delay
                     WeaponRange = 150; //150% range
+                    WeaponDamage = 125; //125% weapon damage
 
                     //Other stats set to base values
-                    WeaponDamage = 100;
                     weaponCritChancePercentage = 100;
                     WeaponCritChanceFlat = 0;
                     WeaponCritDamage = 100;

--- a/Assets/Scripts/WaveManagement/BossSpawner.cs
+++ b/Assets/Scripts/WaveManagement/BossSpawner.cs
@@ -13,8 +13,8 @@ public class BossSpawner : MonoBehaviour
     public int currentWaveNumber;
     private VisualElement document;
     private VisualElement container;
-    public int bossHealth = 2000;
-    public int bossMaxHealth = 2000;
+    private int bossHealth = 1500;
+    private int bossMaxHealth = 1500;
     public GameObject bossHealthBar;
     public GameObject bigBoss;
 
@@ -102,6 +102,6 @@ public class BossSpawner : MonoBehaviour
         {
             Debug.LogError("enemyBossPrefab is not assigned!");
         }
-        bossHealth += 2000;
+        bossHealth += 2500;
     }
 }


### PR DESCRIPTION
 ## Describe your changes

### Weapons
- Rocket Launcher - BUFF
   - Damage scaling: ~100% base~ > 125% base
   - Attack speed scaling: ~33% base~ > 50% base

### Items
- MOAB - BUFF
   - ~Deals 50% Self Damage~ > Removed
   - Damage: Added > +50% weapon damage
- Bigger Barrel - NERF 
   - Extra Pellets: ~6~ > 4
- Band-Aid - BUFF
   - ~1%~ > 2% max health regeneration per ~3~ > 2 seconds
   
### Skills
- Vanish - NERF
   - Duration: ~5~ > 4 seconds

### Enemies
- All Bosses - CHANGE
   - Base health: ~2000~ > 1500
   - Scaling health: ~2000~ > 2500
   - Note: Level 5 boss -500hp, Level 10 unchanged, Level 15 +500 hp, Level 20 +1000 hp, Level 25 +1500 HP
   - Bullet speed: 5 + ~3~ > 1 per boss spawned
- Jumping-Jack - CHANGE
   - Jump Attack
      - Shockwave size increased to match shadow visual
      - Shadow drop pause: ~.5~ > .2 seconds
      - Min delay between jumps: ~7~ > 10-6 seconds, reduced by wave number
      - Max delay between jumps ~12~ > 15-10 seconds, reduced by wave number
- Bombardier - BUFF
   - Bomb explosion
      - Damage: ~10~ > 10 + 5 per boss spawned
      - Note: If spawned at level 5 it deals 10 damage, at level 10 it deals 15 damage, and so on
- Peacekeeper - NERF
   - Riot shield
      - Shield no longer stops explosions and will take damage from both the bullet and explosion
- Melee Enemy - BUFF
   - Level 1
      - Speed: Unchanged > 5
   - Level 2
      - Speed: ~5~ > 7
   - Level 3
      - Speed: ~5~ > 9
   - Level 4
      - Speed: ~7~ > 10
   - Level 5
      - Speed: ~7~ > 11

### Other
- Reroll
   - ~2~ > 1 at the start of the game
   - ADDED: +1 reroll after boss kills